### PR TITLE
Make package settings menu consistent with other plugins

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,22 +1,52 @@
 [
-{
-	"caption": "Preferences",
-	"mnemonic": "n",
-	"id": "preferences",
-	"children": 
-	[
 	{
-		"caption": "Lispindent",
-		"children": [
-		{"caption": "Settings", "command": "open_file", "args":
-		{"file": "${packages}/lispindent/lispindent.sublime-settings"}
-		},
-		{"caption": "Key Bindings – Default", "command": "open_file", "args":
-		{"file": "${packages}/lispindent/Default.sublime-keymap"}},
-		{"caption": "Key Bindings – OSX", "command": "open_file", "args":
-		{"file": "${packages}/lispindent/Default (OSX).sublime-keymap"}}
+		"caption": "Preferences",
+		"mnemonic": "n",
+		"id": "preferences",
+		"children":
+		[
+	    {
+	      "caption": "Package Settings",
+	      "mnemonic": "P",
+	      "id": "package-settings",
+	      "children":
+	      [
+					{
+						"caption": "Lispindent",
+						"children": [
+							{"caption": "Settings - Default", "command": "open_file", "args":
+								{"file": "${packages}/lispindent/lispindent.sublime-settings"}},
+							{"caption": "Settings - User", "command": "open_file", "args":
+								{"file": "${packages}/User/lispindent.sublime-settings"}},
+							{ "caption": "-" },
+							{"caption": "Key Bindings – Default", "command": "open_file", "args": {
+								"file": "${packages}/lispindent/Default (OSX).sublime-keymap",
+								"platform": "OSX"
+							}},
+							{"caption": "Key Bindings – Default", "command": "open_file", "args": {
+								"file": "${packages}/lispindent/Default.sublime-keymap",
+								"platform": "Linux"
+							}},
+							{"caption": "Key Bindings – Default", "command": "open_file", "args": {
+								"file": "${packages}/lispindent/Default.sublime-keymap",
+								"platform": "Windows"
+							}},
+							{"caption": "Key Bindings – User", "command": "open_file", "args": {
+								"file": "${packages}/User/Default (OSX).sublime-keymap",
+								"platform": "OSX"
+							}},
+							{"caption": "Key Bindings – User", "command": "open_file", "args": {
+								"file": "${packages}/User/Default.sublime-keymap",
+								"platform": "Linux"
+							}},
+							{"caption": "Key Bindings – User", "command": "open_file", "args": {
+								"file": "${packages}/User/Default.sublime-keymap",
+								"platform": "Windows"
+							}}
+						]
+					}
+				]
+			}
 		]
 	}
-	]
-}
 ]


### PR DESCRIPTION
- Puts the Lispindent package settings menu under `Preferences > Package Settings`
- Adds separate entries for "Default" and "User" preferences so that users can correctly change and save preferences
- Automatically opens the correct keybindings file for the platform
- Adds a nice separator to the menu
